### PR TITLE
Split variant table by consequence term

### DIFF
--- a/gnomad_bigquery/bq_import_gnomad.py
+++ b/gnomad_bigquery/bq_import_gnomad.py
@@ -17,7 +17,7 @@ def main(args):
         imp_args = parser.parse_args(['--dataset', args.dataset,
                         '--parquet_files', parquet_files,
                         '--table', f'{data_type}_{data}',
-                        '--write_disposition', 
+                        '--write_disposition',
                         'WRITE_TRUNCATE' if args.overwrite else 'WRITE_EMPTY',
                         '--description', description])
         bq_import.main(imp_args)
@@ -37,7 +37,11 @@ def main(args):
             import_data(input_dir, version, data_type, 'meta', get_meta_table_desc(version, data_type))
 
         if args.import_variants:
-            import_data(input_dir, version, data_type, 'variants', get_variants_table_desc(version, data_type))
+            if args.split_variant_table:
+                import_data(input_dir, version, data_type, 'variants_in_gt', get_variants_table_desc(version, data_type, split=True, in_gt=True))
+                import_data(input_dir, version, data_type, 'variants_not_in_gt', get_variants_table_desc(version, data_type, split=True, in_gt=False))
+            else:
+                import_data(input_dir, version, data_type, 'variants', get_variants_table_desc(version, data_type))
 
         if args.import_genotypes:
             import_data(input_dir, version, data_type, 'genotypes', get_genotypes_table_desc(version, data_type))
@@ -52,6 +56,7 @@ if __name__ == '__main__':
     parser.add_argument('--dataset', help='Dataset to create the table in. (default: gnomad)', default='gnomad')
     parser.add_argument('--import_meta', help='Imports samples metadata.', action='store_true')
     parser.add_argument('--import_variants', help='Imports variants.', action='store_true')
+    parser.add_argument('--split_variant_table', help='Whether the variant table was split by genotype table overlap on export', action="store_true")
     parser.add_argument('--import_genotypes', help='Imports genotypes.', action='store_true')
     parser.add_argument('--input_dir', help='Input root directory (assumes data was produced with `bq_export.py`). default: gs://gnomad-tmp/bq', default='gs://gnomad-tmp/bq')
     parser.add_argument('--overwrite', help='If set, overwrites existing table.', action='store_true')

--- a/gnomad_bigquery/bq_table_descriptions.py
+++ b/gnomad_bigquery/bq_table_descriptions.py
@@ -7,7 +7,7 @@ def get_variants_table_desc(version: int, data_type: str, split=False, in_gt=Fal
     if split:
         if in_gt:
             return f"""This table contains gnomad v{version} {dtype} variants that are filtered similarly to the
-             genotypes table, optionally filtered by a least consequence term and max AF. 
+             genotypes table i.e., optionally filtered by a least consequence term and max AF. 
             Notes:
             * All variants were split, so multi-allelic sites are represented as multiple rows (one per non-ref allele)
             * Only VEP transcript annotations are available (non-coding annotations aren't)

--- a/gnomad_bigquery/bq_table_descriptions.py
+++ b/gnomad_bigquery/bq_table_descriptions.py
@@ -2,13 +2,29 @@ from gnomad.utils.vep import CSQ_ORDER
 
 LEAST_CSQ = '3_prime_UTR_variant'
 
-def get_variants_table_desc(version: int, data_type: str = None):
+def get_variants_table_desc(version: int, data_type: str, split=False, in_gt=False):
     dtype = '' if data_type is None else f' {data_type}'
-    return f"""This table contains all gnomad v{version} {dtype} variants.
-    Notes:
-    * All variants were split, so multi-allelic sites are represented as multiple rows (one per non-ref allele)
-    * Only VEP transcript annotations are available (non-coding annotations aren't)
-    """
+    if split:
+        if in_gt:
+            return f"""This table contains gnomad v{version} {dtype} variants that are filtered similarly to the
+             genotypes table, optionally filtered by a least consequence term and max AF. 
+            Notes:
+            * All variants were split, so multi-allelic sites are represented as multiple rows (one per non-ref allele)
+            * Only VEP transcript annotations are available (non-coding annotations aren't)
+            """
+        else:
+            return f"""This table contains gnomad v{version} {dtype} variants that are filtered out of the
+             genotypes table by not meeting the threshold for the least consequence term and max AF. 
+            Notes:
+            * All variants were split, so multi-allelic sites are represented as multiple rows (one per non-ref allele)
+            * Only VEP transcript annotations are available (non-coding annotations aren't)
+            """
+    else:
+        return f"""This table contains all gnomad v{version} {dtype} variants.
+        Notes:
+        * All variants were split, so multi-allelic sites are represented as multiple rows (one per non-ref allele)
+        * Only VEP transcript annotations are available (non-coding annotations aren't)
+        """
 
 
 def get_meta_table_desc(version: int, data_type: str = None):
@@ -33,9 +49,9 @@ def get_genotypes_table_desc(version: int, data_type: str = None):
     """
 
 
-def get_data_view_desc(version: int, data_type: str = None):
+def get_data_view_desc(version: int, data_type: str = None, split_variant_table=False):
     if data_type is not None:
-        view_tables_str = f'{data_type}_variants, {data_type}_genotypes and {data_type}_meta tables'
+        view_tables_str = f'{data_type}_variants{"_in_gt" if split_variant_table else ""}, {data_type}_genotypes and {data_type}_meta tables'
         n_tables_str = '3 tables.'
     else:
         view_tables_str = 'exomes and genomes views.'
@@ -43,3 +59,13 @@ def get_data_view_desc(version: int, data_type: str = None):
 
     return f"""This view contains a flat version of joining the gnomAD v{version} {view_tables_str}.
     To get more information about the content of this view, take a look a the description of those {n_tables_str}."""
+
+
+def get_variants_view_desc(version: int, data_type: str):
+    dtype = '' if data_type is None else f' {data_type}'
+    return f"""This table is a VARIANTS ONLY view of all gnomad v{version} {dtype} variants, 
+    a union of variants in the genotypes table and variants not in the genotypes table.
+        Notes:
+        * All variants were split, so multi-allelic sites are represented as multiple rows (one per non-ref allele)
+        * Only VEP transcript annotations are available (non-coding annotations aren't)
+        """

--- a/gnomad_bigquery/create_bq_views.py
+++ b/gnomad_bigquery/create_bq_views.py
@@ -61,7 +61,7 @@ def get_data_view(client: bigquery.Client, data_type: str, dataset: bigquery.Dat
 def union_variant_view(client: bigquery.Client, data_type: str, dataset: bigquery.DatasetReference) -> str:
     """
     This creates a single view over 'exomes' or 'genomes' variants only if they were split 
-    by whteher the variant was in the genotypes table.
+    by whether the variant was in the genotypes table.
 
     :param CLient client: BQ client
     :param str data_type: One of 'exomes' or 'genomes'

--- a/gnomad_bigquery/create_bq_views.py
+++ b/gnomad_bigquery/create_bq_views.py
@@ -4,9 +4,8 @@ import sys
 from google.cloud import bigquery
 
 from gnomad_bigquery.bq_table_descriptions import (get_data_view_desc,
-                                                   get_genotypes_table_desc,
                                                    get_meta_table_desc,
-                                                   get_variants_table_desc)
+                                                   get_variants_view_desc)
 from gnomad_bigquery.bq_utils import create_table, create_union_query, logger, GNOMAD_VERSIONS
 
 POPMAX_SQL = """
@@ -19,7 +18,7 @@ POPMAX_SQL = """
             """
 
 
-def get_data_view(client: bigquery.Client, data_type: str, dataset: bigquery.DatasetReference) -> str:
+def get_data_view(client: bigquery.Client, data_type: str, dataset: bigquery.DatasetReference, split_variant_table=False) -> str:
     """
     This creates a view over one of the 'exomes' or 'genomes' data regrouping the
     variants, genotypes and sample metadata into a single view.
@@ -33,7 +32,12 @@ def get_data_view(client: bigquery.Client, data_type: str, dataset: bigquery.Dat
 
     # Exclude data_type from meta, so we can use * in main  query
     meta_table = client.get_table(dataset.table(f'{data_type}_meta'))
-    variants_table = client.get_table(dataset.table(f'{data_type}_variants'))
+    if split_variant_table:
+        variants_table = client.get_table(dataset.table(f'{data_type}_variants_in_gt'))
+        variant_sql = 'variants_in_gt'
+    else:
+        variants_table = client.get_table(dataset.table(f'{data_type}_variants'))
+        variant_sql = 'variants'
     genotypes_table = client.get_table(dataset.table(f'{data_type}_genotypes'))
     meta_cols = [f.name for f in meta_table.schema if f.name != 'data_type']
     genotypes_cols = [f.name for f in genotypes_table.schema]
@@ -48,9 +52,36 @@ def get_data_view(client: bigquery.Client, data_type: str, dataset: bigquery.Dat
            {",".join([f'meta.{f}' for f in meta_cols if f not in genotypes_cols])},
             {POPMAX_SQL}
             
-           FROM `{dataset.project}.{dataset.dataset_id}.{data_type}_variants` as v
+           FROM `{dataset.project}.{dataset.dataset_id}.{data_type}_{variant_sql}` as v
     LEFT JOIN `{dataset.project}.{dataset.dataset_id}.{data_type}_genotypes` as gt ON v.idx = gt.v
     LEFT JOIN `{dataset.project}.{dataset.dataset_id}.{data_type}_meta` as meta ON gt.s = meta.s    
+    """
+
+
+def union_variant_view(client: bigquery.Client, data_type: str, dataset: bigquery.DatasetReference) -> str:
+    """
+    This creates a single view over 'exomes' or 'genomes' variants only if they were split 
+    by whteher the variant was in the genotypes table.
+
+    :param CLient client: BQ client
+    :param str data_type: One of 'exomes' or 'genomes'
+    :param DatasetReference dataset: BQ Dataset
+    :return: SQL for the view
+    :rtype: str
+    """
+    variant_table = client.get_table(dataset.table(f'{data_type}_variants_in_gt'))
+    variants_cols = [f.name for f in variant_table.schema]
+
+    return f"""
+
+    SELECT {",".join([f'{f}' for f in variants_cols])},
+            {POPMAX_SQL}
+           FROM `{dataset.project}.{dataset.dataset_id}.{data_type}_variants_in_gt`
+    UNION ALL
+
+    SELECT {",".join([f'{f}' for f in variants_cols ])},
+            {POPMAX_SQL}
+            FROM `{dataset.project}.{dataset.dataset_id}.{data_type}_variants_not_in_gt`
     """
 
 
@@ -70,10 +101,18 @@ def main(args):
         logger.info(f"Creating {data_type} view")
         create_table(client,
                     dataset.table(data_type),
-                    sql=get_data_view(client, data_type, dataset),
+                    sql=get_data_view(client, data_type, dataset, args.split_variant_table),
                     view=True,
                     overwrite=args.overwrite,
-                    description=get_data_view_desc(version, data_type)
+                    description=get_data_view_desc(version, data_type, args.split_variant_table)
+                    )
+        if args.split_variant_table:
+            create_table(client,
+                    dataset.table(f'{data_type}_all_variants'),
+                    sql=union_variant_view(client, data_type, dataset),
+                    view=True,
+                    overwrite=args.overwrite,
+                    description=get_variants_view_desc(version, data_type)
                     )
 
     if 'exomes' in data_types and 'genomes' in data_types:  
@@ -119,6 +158,7 @@ if __name__ == '__main__':
     parser.add_argument('--dataset', help='Dataset to create the table in. (default: gnomad)', default='gnomad')
     parser.add_argument('--version', help="Version of gnomAD", choices=GNOMAD_VERSIONS, type=int, required=True)
     parser.add_argument('--overwrite', help='If set, will overwrite all existing tables.', action='store_true')
+    parser.add_argument('--split_variant_table', help='Whether the variant table was split by a least consequence term', action='store_true')
     args = parser.parse_args()
 
     if not args.exomes and not args.genomes:


### PR DESCRIPTION
This PR adds the option to split the variant table by the same vep consequence filtering that the genotypes table undergoes. This produces a smaller table to join with in BigQuery and thus more efficient searching. I am definitely open to better naming/terminology for the variant tables/views/descriptions. I did not choose "coding" vs. "non-coding" since the least consequence term is user input and the default term actually belongs to non-coding set ->  [gnomad.utils.vep.CSQ_NON_CODING](https://github.com/broadinstitute/gnomad_methods/blob/c91efe75817a46602fbad007926e4eb4a1593659/gnomad/utils/vep.py#L35l) . I have tested this in the mwilson dataset in BigQuery. 